### PR TITLE
fixed overflow on main window

### DIFF
--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -14,6 +14,7 @@ body {
   border-radius: 50%;
   display: flex;
   justify-content: center;
+  overflow: hidden;
 }
 
 video {


### PR DESCRIPTION
Hi!
I removed the annoying overflow bars of the main browser window.

Before:
<img width="200" alt="schermata 2018-09-26 alle 11 54 04" src="https://user-images.githubusercontent.com/14977595/46072552-f3809680-c182-11e8-9a64-e3044a6de175.png">

After:
<img width="166" alt="schermata 2018-09-26 alle 11 54 24" src="https://user-images.githubusercontent.com/14977595/46072561-faa7a480-c182-11e8-8282-a697413ae684.png">
